### PR TITLE
Add dashboard auth middleware

### DIFF
--- a/apps/nextjs-frontend/middleware.ts
+++ b/apps/nextjs-frontend/middleware.ts
@@ -1,0 +1,17 @@
+import {NextResponse, type NextRequest} from 'next/server';
+
+// Protect dashboard routes by ensuring access token cookie exists
+export function middleware(request: NextRequest) {
+  const accessToken = request.cookies.get('access_token');
+  if (!accessToken) {
+    const loginUrl = new URL('/login', request.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+// Apply middleware only to dashboard pages
+export const config = {
+  matcher: ['/dashboard/:path*'],
+};


### PR DESCRIPTION
## Summary
- protect dashboard pages with a new frontend middleware

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68497a08e8a88330ba010afee532d552